### PR TITLE
Replaced using psycopg2-binary with psycopg2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ sentry-sdk = "==1.14.0"
 celery = "==5.2.6"
 django-filter = "*"
 drf-yasg = "*"
-psycopg2-binary = "*"
+psycopg2 = "*"
 pillow = "*"
 
 [dev-packages]


### PR DESCRIPTION
It's not recommended to use psycopg-binary for production